### PR TITLE
Make sure to return from original link handler to preserve Python → JS bridge

### DIFF
--- a/TomatoClock/lib/component.py
+++ b/TomatoClock/lib/component.py
@@ -36,7 +36,7 @@ class anki_deckbrowser(DeckBrowser):
         if url.startswith("report_refresh"):
             self.report_recent_days = int(url.replace("report_refresh", ""))
             mw.deckBrowser.refresh()
-        super(anki_deckbrowser, self)._linkHandler(url)
+        return super(anki_deckbrowser, self)._linkHandler(url)
 
     _body = """
         <center>
@@ -125,7 +125,7 @@ class anki_overview(Overview):
             self.report_recent_days = int(url.replace("report_refresh", ""))
             mw.overview.refresh()
         else:
-            super(anki_overview, self)._linkHandler(url)
+            return super(anki_overview, self)._linkHandler(url)
 
     def show_update_logs(self):
         if ProfileConfig.ttc_current_version != self.addon_version:
@@ -254,7 +254,7 @@ class anki_reviewer(Reviewer):
             if UserConfig.SHOW_ANSWER_ON_CARD_TIMEOUT:
                 self._showAnswer()
         else:
-            super(anki_reviewer, self)._linkHandler(url)
+            return super(anki_reviewer, self)._linkHandler(url)
 
     def NO_bottomHTML(self): #deac
         if not self.mode:


### PR DESCRIPTION
Hi Ali,

I've been trying to resolve common add-on conflicts recently, and one of the key issues I've found were problems with the implementation of link handler / onBridgeCmd patches. The crux is that in Anki 2.1, the link handler and onBridgeCmd no longer only act as a one-way street between JS and Python, but can also pass return values from Python to JS via an optional `pycmd` callback (cf. https://github.com/dae/anki/pull/228 and https://github.com/dae/anki/commit/56e1643bfa0391c71d3323b7d12b77c9fa8af551).

Unfortunately this is not as obvious in Anki's source code as it probably should be (something I plan to file a PR for), and expectedly many add-ons do not return from their custom link handlers. As a result they interfere with other add-ons that do depend on this Python → JS bridge (e.g. Pop-up Dictionary).

So what I'm trying to do at the moment is to go through the add-ons in question and either file PRs to fix the problem, or notify the authors about the situation. Since I likely won't be able to catch all cases, I'd very much appreciate it if you could check and see if you can find any other add-ons that have the same problem.

Thanks a lot in advance!